### PR TITLE
docs: update documentation to reflect recent JS build changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# Eleventy Starter
+# Eleventy Starter (Advanced)
 
 First time setup:
 
 - [Click this link and make a new
-repo.](https://github.com/dustinwhisman/eleventy-starter/generate) This will
+repo.](https://github.com/dustinwhisman/eleventy-starter-advanced/generate) This will
 open a form for you to create a new repo with all the files from this one.
 
 - Out of the box, you should have:
@@ -11,7 +11,7 @@ open a form for you to create a new repo with all the files from this one.
     catch-all 404 page
   - [x] Sass support with minimal/brutalist styles ready to go, including dark
     mode
-  - [x] JS bundling with modern/legacy builds
+  - [x] JS bundling, minification, and code splitting
   - [x] Minimal PWA requirements already met
   - [x] A service worker with precaching and a basic
     cache-falling-back-to-network strategy in place
@@ -46,8 +46,10 @@ Things to update:
 - [`.lighthouserc.js`](./.lighthouserc.js): change the list of URLs to match pages that you want audited by Lighthouse, or delete them and uncomment the `maxAutodiscoverUrls` line to audit all pages
 
 Things to delete:
-- `src/assets/js/*`: the example JS files that aren't actually useful
-- `src/pages/blog`: example blog entries (the index page might still be useful, though)
+- `src/assets/js/example.js`: the example JS file that isn't actually useful, as
+  well as the `add.js` and `subtract.js` utility JS files
+- `src/pages/blog`: example blog entries (the index page might still be useful,
+  though)
 - `src/pages/docs`: documentation geared toward developers
 - Any other pages or templates that won't be needed
 
@@ -204,24 +206,20 @@ follows:
 
 ### JavaScript
 
-JavaScript files are bundled by Rollup from `src/assets/js` into modern or
-legacy bundles in `dist/assets/js/bundled` or `dist/assets/js/legacy`,
-respectively. Legacy bundles use Babel to transpile JS into syntax understood by
-older browsers. To deliver the right scripts to the right browsers, follow the
-module/nomodule pattern:
+JavaScript files are processed by esbuild, which bundles/minifies JS and handles
+code splitting. The output is intended for browsers that support ES modules, so
+if you need support for legacy browsers, you'll need to add support yourself. If
+you do generate legacy builds, be sure to use the `module/nomodule` pattern to
+prevent browsers from loading/running the wrong scripts.
+
+By convention, any files in `src/assets/js` will be treated as entry points, and
+the processed output will be written to `dist/assets/js`.
 
 ```html
-<script src="/dist/assets/js/bundled/scripts.js" type="module"></script>
+<script src="/dist/assets/js/scripts.js" type="module"></script>
+
+<!-- use this for legacy bundles or fallbacks for older browsers -->
 <script src="/dist/assets/js/legacy/scripts.js" nomodule></script>
-```
-
-If you don't want to serve bundled or transpiled versions of your scripts, we
-recommend using the `.mjs` file extension for your JS files, and using
-`type=module` in your `script` tags. This may improve performance, depending on
-the size and number of files that would otherwise be bundled together.
-
-```html
-<script src="/dist/assets/js/non-bundled-script.mjs" type="module"></script>
 ```
 
 ### Linting and Testing

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "eleventy-starter",
+  "name": "eleventy-starter-advanced",
   "version": "0.0.1",
   "author": "Dustin Whisman",
   "license": "ISC",

--- a/src/pages/docs/javascript.njk
+++ b/src/pages/docs/javascript.njk
@@ -12,16 +12,17 @@ tags: docs
       Using JavaScript
     </h1>
     <p>
-      This project handles JavaScript by convention. Putting a <code>.js</code> or
-      <code>.mjs</code> file in <code>src/assets/js</code> will automatically
-      signify it as an entry point for bundling. Any subfolders will not be used
-      as entrypoints, so it's recommended to organize your JS in subfolders, and
+      This project handles JavaScript by convention. Putting a <code>.js</code>
+      file in <code>src/assets/js</code> will automatically signify it as an
+      entry point for esbuild to process. Any subfolders will not be used as
+      entrypoints, so it's recommended to organize your JS in subfolders, and
       then import what you need into files at the <code>src/assets/js</code>
       level.
     </p>
     <p>
-      For example, given this structure, two bundles would be created for
-      <code>example.js</code> and <code>example-2.mjs</code>.
+      For example, given this structure, an output file would be created for
+      <code>example.js</code>, but not for <code>add.js</code> or
+      <code>subtract.js</code>.
     </p>
 <pre>
 src/assets/js/
@@ -29,80 +30,57 @@ src/assets/js/
 |  |– add.js
 |  |– subtract.js
 |– example.js
-|– example-2.mjs
 </pre>
 
     <p>
-      Those bundled JS files would land in <code>dist/assets/js/bundled</code>,
-      keeping their original names and file extensions.
+      The output JS files would land in <code>dist/assets/js</code>, keeping
+      their original names and file extensions. With code splitting, there may
+      be additional files written there with names like
+      <code>chunk-5X6LSU5U.js</code>. Those chunks include code that's shared
+      between entrypoints, and you don't need to do anything special with them.
     </p>
 <pre>
-dist/assets/js/bundled/
+dist/assets/js/
 |– example.js
-|– example-2.mjs
 </pre>
 
     <p>
-      Include the file in a standard <code>script</code> element, and you're good
-      to go.
+      Include the file in a standard <code>script</code> element, and you're
+      good to go.
     </p>
 <pre>
-&lt;script src="/assets/js/bundled/example.js"&gt;&lt;/script&gt;
-</pre>
-
-    <h2>
-      Non-Bundled Scripts
-    </h2>
-    <p>
-      What if you don't want to bundle your JS, though? Support for ES modules is
-      pretty good these days, so it may not make sense to bundle everything. To
-      handle that use-case, your <code>src/assets/js</code> folder is copied to
-      <code>dist/assets/js</code>, so you can use those files directly.
-    </p>
-    <p>
-      For safety, make sure to specify the file extension in your imports, so
-      browsers will know how to find the correct files (if you forget, eslint will
-      yell at you). Its recommended to use the <code>.mjs</code> extension to make
-      it clear that you don't intend to use the bundled version, even though one
-      will be created at build time.
-    </p>
-    <p>
-      You will also need to specify <code>type="module"</code> in your
-      <code>script</code> tag.
-    </p>
-<pre>
-// example-2.mjs
-import { add } from './utilities/add.js';
-import { subtract } from './utilities/subtract.js';
-
-console.log(add(4, 4));
-console.log(subtract(5, 2));
-
-&lt;!-- html --&gt;
-&lt;script src="/assets/js/example-2.mjs" type="module"&gt;&lt;/script&gt;
+&lt;script src="/assets/js/example.js" type="module"&gt;&lt;/script&gt;
 </pre>
 
     <h2>
       Legacy Bundles
     </h2>
     <p>
+      To keep project maintenance at a minimum, and to keep up with the times,
+      legacy bundles are not supported by default in this project. If you need
+      to support older browsers, you'll need to bring your own build process for
+      legacy bundles.
+    </p>
+    <p>
       In case you need to support an older browser that doesn't support ES
       Modules, you can use the module/nomodule pattern to serve modern JS to
       modern browsers and legacy JS to older browsers (lookin' at you IE11).
     </p>
     <p>
-      Every entrypoint is bundled twice, once for modern browsers, and once for
-      legacy browsers.
+      The <code>type="module"</code> attribute prevents non-supporting browsers
+      from trying to run the script, and the <code>nomodule</code> attribute
+      tells modern browsers to not even bother with downloading the script.
     </p>
 <pre>
-&lt;!-- serve bundled script to modern browsers --&gt;
-&lt;script src="/assets/js/bundled/example.js" type="module"&gt;&lt;/script&gt;
+&lt;script src="/assets/js/example.js" type="module"&gt;&lt;/script&gt;
 &lt;script src="/assets/js/legacy/example.js" nomodule&gt;&lt;/script&gt;
-
-&lt;!-- serve ES Modules to modern browsers --&gt;
-&lt;script src="/assets/js/example-2.mjs" type="module"&gt;&lt;/script&gt;
-&lt;script src="/assets/js/legacy/example-2.js" nomodule&gt;&lt;/script&gt;
 </pre>
+
+    <p>
+      Even if you aren't fully supporting older browsers, you can use this
+      pattern to provide a fallback experience to avoid your site being
+      completely broken for users.
+    </p>
   </article>
 {% endblock %}
 

--- a/src/root/manifest.json
+++ b/src/root/manifest.json
@@ -1,6 +1,6 @@
 {
   "short_name": "11ty Starter",
-  "name": "Eleventy Starter",
+  "name": "Eleventy Starter Advanced",
   "icons": [
     {
       "src": "favicon.svg",


### PR DESCRIPTION
Fix up outdated names and documentation throughout the project that referenced `eleventy-starter` or the old JS setup that included legacy bundle support.